### PR TITLE
Add ports JSON generator and schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Node modules
+nginx/fluxsign/node_modules/

--- a/nginx/etc/nginx/conf.d/flux-dashboard.conf
+++ b/nginx/etc/nginx/conf.d/flux-dashboard.conf
@@ -1,0 +1,4 @@
+location = /dashboard/api/ports {
+    alias /var/lib/flux-dashboard/ports.json;
+    add_header Cache-Control "no-cache";
+}

--- a/nginx/etc/systemd/system/generate_ports_json.service
+++ b/nginx/etc/systemd/system/generate_ports_json.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Generate ports.json for Flux dashboard
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/python3 /generate_ports_json.py
+
+[Install]
+WantedBy=multi-user.target

--- a/nginx/etc/systemd/system/generate_ports_json.timer
+++ b/nginx/etc/systemd/system/generate_ports_json.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run generate_ports_json every 15 seconds
+
+[Timer]
+OnBootSec=15s
+OnUnitActiveSec=15s
+Unit=generate_ports_json.service
+
+[Install]
+WantedBy=timers.target

--- a/nginx/generate_ports_json.py
+++ b/nginx/generate_ports_json.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Generate ports.json for dashboard from mapping files."""
+import json
+from datetime import datetime
+import os
+from urllib.request import urlopen
+from urllib.error import URLError
+
+IP_MAPPING_FILE = "/usr/share/nginx/html/ip_mapping.json"
+PORT_MAPPING_FILE = "/usr/share/nginx/html/port_mapping.json"
+OUTPUT_FILE = "/var/lib/flux-dashboard/ports.json"
+
+def load_json(path: str):
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+
+def lookup_country(ip: str):
+    if not ip:
+        return None
+    try:
+        with urlopen(f"https://ipinfo.io/{ip}/country", timeout=5) as resp:
+            return resp.read().decode().strip()
+    except URLError:
+        return None
+
+
+def main():
+    ip_mapping = load_json(IP_MAPPING_FILE)
+    port_mapping = load_json(PORT_MAPPING_FILE)
+
+    result = {
+        "generatedAt": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "projects": []
+    }
+
+    for project, ports in port_mapping.items():
+        ips = ip_mapping.get(project, [])
+        external_ip = ips[0] if ips else None
+        country = lookup_country(external_ip) if external_ip else None
+        project_entry = {"name": project, "ports": []}
+        for port in ports:
+            project_entry["ports"].append({
+                "port": port,
+                "status": "active" if external_ip else "inactive",
+                "externalIp": external_ip,
+                "country": country,
+                "uptime": None
+            })
+        result["projects"].append(project_entry)
+
+    os.makedirs(os.path.dirname(OUTPUT_FILE), exist_ok=True)
+    with open(OUTPUT_FILE, "w") as f:
+        json.dump(result, f)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate ports.json from mapping files for dashboard
- expose `/dashboard/api/ports` in nginx with no-cache header
- run generator periodically via systemd timer

## Testing
- `python3 -m py_compile nginx/generate_ports_json.py`
- `python3 nginx/generate_ports_json.py`


------
https://chatgpt.com/codex/tasks/task_e_68b469a26124832081f80d854e294dc1