### PR TITLE
Resolve merge artifacts and parametrize config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,7 @@
 ```bash
 pip install -r requirements.txt && pytest
 ```
-=======
 
 ### IP-сервисы
 
 Для определения IP и страны используется последовательность сервисов: сначала [IPHub](https://iphub.info/) с ключом `IPHUB_API_KEY`, затем `ipwho.is`, и при ошибке — `api.2ip.io` с токеном `TWOIP_API_TOKEN`.
-

--- a/nginx/fluxsign/check_blacklist.py
+++ b/nginx/fluxsign/check_blacklist.py
@@ -20,9 +20,7 @@ USE_API = True
 # === Config from .env or defaults ===
 API_KEY = os.getenv("IPHUB_API_KEY", "").strip()
 TWOIP_API_TOKEN = os.getenv("TWOIP_API_TOKEN", "").strip()
-BLACKLIST_FILE = Path("/usr/share/nginx/html/blacklist.json")
-WHITELIST_FILE = Path("/usr/share/nginx/html/whitelist.json")
-=======
+
 def _get_env_path(var_name: str, default: str) -> Path:
     value = os.getenv(var_name)
     if not value:

--- a/nginx/home/proxyuser/run_add_project_address.py
+++ b/nginx/home/proxyuser/run_add_project_address.py
@@ -5,12 +5,6 @@ import os
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
-PORTS_FILE = "/usr/share/nginx/html/port_mapping.json"
-IP_MAPPING_FILE = "/usr/share/nginx/html/ip_mapping.json"
-IP_COUNTRY_FILE = "/usr/share/nginx/html/ip_country.json"
-PORTS_JSON_FILE = "/usr/share/nginx/html/ports.json"
-
-=======
 PORTS_FILE = os.getenv("PORTS_FILE", "/usr/share/nginx/html/port_mapping.json")
 if "PORTS_FILE" not in os.environ:
     logging.error(
@@ -21,6 +15,18 @@ IP_MAPPING_FILE = os.getenv("IP_MAPPING_FILE", "/usr/share/nginx/html/ip_mapping
 if "IP_MAPPING_FILE" not in os.environ:
     logging.error(
         f"Переменная IP_MAPPING_FILE не установлена. Используется значение по умолчанию: {IP_MAPPING_FILE}"
+    )
+
+IP_COUNTRY_FILE = os.getenv("IP_COUNTRY_FILE", "/usr/share/nginx/html/ip_country.json")
+if "IP_COUNTRY_FILE" not in os.environ:
+    logging.error(
+        f"Переменная IP_COUNTRY_FILE не установлена. Используется значение по умолчанию: {IP_COUNTRY_FILE}"
+    )
+
+PORTS_JSON_FILE = os.getenv("PORTS_JSON_FILE", "/usr/share/nginx/html/ports.json")
+if "PORTS_JSON_FILE" not in os.environ:
+    logging.error(
+        f"Переменная PORTS_JSON_FILE не установлена. Используется значение по умолчанию: {PORTS_JSON_FILE}"
     )
 
 def load_json(file_path):


### PR DESCRIPTION
## Summary
- parameterize configuration paths in run_add_project_address.py via environment variables
- unify path configuration in check_blacklist.py and drop leftover merge markers
- clean README merge markers and document IP services

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b459e1e0488320886ed6bd29af495f